### PR TITLE
Introduce unified balances (ready to test)

### DIFF
--- a/clearnet/channel.go
+++ b/clearnet/channel.go
@@ -79,20 +79,10 @@ func GetChannelByID(tx *gorm.DB, channelID string) (*Channel, error) {
 	return &channel, nil
 }
 
-// getChannelForParticipant finds the channel between a participant and the broker
-func getChannelForParticipant(tx *gorm.DB, participant string) (*Channel, error) {
-	var channel Channel
-	if err := tx.Where("participant_a = ? AND participant_b = ? AND status = ?",
-		participant, BrokerAddress, ChannelStatusOpen).Order("nonce DESC").First(&channel).Error; err != nil {
-		return nil, fmt.Errorf("no open channel found for participant %s: %w", participant, err)
-	}
-	return &channel, nil
-}
-
 // CheckExistingChannels checks if there is an existing open channel on the same network between participant A and B
-func CheckExistingChannels(tx *gorm.DB, participantA, participantB, networkID string) (*Channel, error) {
+func CheckExistingChannels(tx *gorm.DB, participantA, participantB, networkID, token string) (*Channel, error) {
 	var channel Channel
-	err := tx.Where("participant_a = ? AND participant_b = ? AND network_id = ? AND status = ?", participantA, participantB, networkID, ChannelStatusOpen).
+	err := tx.Where("participant_a = ? AND participant_b = ? AND network_id = ? AND token = ? AND status = ?", participantA, participantB, networkID, token, ChannelStatusOpen).
 		First(&channel).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/clearnet/docs/Broker.spec.md
+++ b/clearnet/docs/Broker.spec.md
@@ -263,13 +263,15 @@ If authentication is successful, the server responds:
 ### Get Ledger Balances
 
 Retrieves the balances of all participants in a specific ledger account.
+- AccountID for unified balance is `asset+participant_address`.
+- AccountID for balance in a specific channel is `channelID`.
 
 **Request:**
 
 ```json
 {
   "req": [2, "get_ledger_balances", [{
-    "acc": "0x1234567890abcdef..."
+    "acc": "usdc0x1234567890abcdef..."
   }], 1619123456789],
   "sig": ["0x9876fedcba..."]
 }
@@ -281,11 +283,11 @@ Retrieves the balances of all participants in a specific ledger account.
 {
   "res": [2, "get_ledger_balances", [[
     {
-      "address": "0x1234567890abcdef...",
+      "address": "usdc0x1234567890abcdef...",
       "amount": 100000
     },
     {
-      "address": "0x2345678901abcdef...",
+      "address": "usdc0x2345678901abcdef...",
       "amount": 200000
     }
   ]], 1619123456789],
@@ -315,7 +317,7 @@ Creates a virtual application between participants.
       "challenge": 86400,
       "nonce": 1
     },
-    "token": "0xTokenAddress",
+    "token": "usdc",
     "allocations": [100, 100]
   }], 1619123456789],
   "int": [100, 100], // Initial funding intent from 0, 0

--- a/clearnet/vapp.go
+++ b/clearnet/vapp.go
@@ -16,7 +16,7 @@ type VApp struct {
 	Status       ChannelStatus  `gorm:"column:status;not null"`
 	Challenge    uint64         `gorm:"column:challenge;"`
 	Nonce        uint64         `gorm:"column:nonce;not null"`
-	Token        string         `gorm:"column:token;not null"`
+	Asset        string         `gorm:"column:token;not null"`
 	Weights      pq.Int64Array  `gorm:"type:integer[];column:weights"`
 	Quorum       uint64         `gorm:"column:quorum;default:100"`
 	Version      uint64         `gorm:"column:version;default:1"`


### PR DESCRIPTION
Description:

- The solution supports multiasset and multinetwork while keeping old RPC.
- Channels with broker: max one channel per token per network.
- vApps are limited to one asset per vApp (usdc).
- different vApps support different tokens.
- user can deposit into one vApp from multiple chains
- user can withdraw on any chain

Frontend update guide:

- When creating vApp you should pass “usdc" into the token field.
- To fetch unified balance, you should pass “usdc+participantAddress” (“usdc0x12345”) into the "acc" field.
- Channel balance if fetched same as before.

**Now, ```participant_change``` in resize means how much you want to allocate from unified account into the channel on that network.**

> I you want to withdraw 100 from your unified balance, and your channel balance on the target chain channel is 0, then you have to call resize with participant change -100 on that network.

> If your channel balance on the target network is 20, and you want to withdraw 100 from your unified balance, then you need to call resize with participant change -80. 
